### PR TITLE
Fix loadFeatures reference error

### DIFF
--- a/pet-management-app/src/app/globals.css
+++ b/pet-management-app/src/app/globals.css
@@ -49,7 +49,7 @@
 
 @layer base {
   * {
-    @apply border-border;
+    @apply border-gray-200;
   }
   body {
     @apply bg-background text-foreground;

--- a/pet-management-app/src/hooks/useFeatures.ts
+++ b/pet-management-app/src/hooks/useFeatures.ts
@@ -10,10 +10,6 @@ export function useFeatures(userId?: string) {
   const [availableFeatures, setAvailableFeatures] = useState<FeatureConfig[]>([])
   const [loading, setLoading] = useState(true)
 
-  useEffect(() => {
-    loadFeatures()
-  }, [userId, session, status, loadFeatures])
-
   const loadFeatures = useCallback(async () => {
     if (status === 'loading') return
     
@@ -39,6 +35,10 @@ export function useFeatures(userId?: string) {
       setLoading(false)
     }
   }, [status, userId, session?.user?.id])
+
+  useEffect(() => {
+    loadFeatures()
+  }, [loadFeatures])
 
   const isFeatureEnabled = (featureName: string): boolean => {
     return ClientFeatureManager.isFeatureEnabled(featureName, enabledFeatures)


### PR DESCRIPTION
Fix `ReferenceError` in `useFeatures` hook and invalid Tailwind `border-border` class.

The `ReferenceError` occurred because `loadFeatures` was referenced in a `useEffect` dependency array before its `useCallback` declaration. This PR moves the `loadFeatures` definition above the `useEffect` to ensure it's initialized. Additionally, `border-border` was not a valid Tailwind utility class, causing a compilation error, and has been replaced with `border-gray-200`.

---
<a href="https://cursor.com/background-agent?bcId=bc-3dce419e-7aea-4907-baf4-1280f0957e2b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-3dce419e-7aea-4907-baf4-1280f0957e2b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>