### PR TITLE
Fix dialog button click event type

### DIFF
--- a/pet-management-app/src/components/ui/dialog.tsx
+++ b/pet-management-app/src/components/ui/dialog.tsx
@@ -53,9 +53,21 @@ const DialogTrigger = React.forwardRef<HTMLButtonElement, DialogTriggerProps>(
     }
 
     if (asChild && React.isValidElement(children)) {
-      return React.cloneElement(children as React.ReactElement<{ onClick?: (e: React.MouseEvent) => void }>, {
-        ...(children.props || {}),
-        onClick: handleClick,
+      const childElement = children as React.ReactElement<{ onClick?: (e: React.MouseEvent) => void; ref?: React.Ref<HTMLElement> }>
+      
+      const combinedOnClick = (e: React.MouseEvent) => {
+        onOpenChange(true)
+        if (onClick) {
+          onClick(e as React.MouseEvent<HTMLButtonElement>)
+        }
+        if (childElement.props.onClick) {
+          childElement.props.onClick(e)
+        }
+      }
+
+      return React.cloneElement(childElement, {
+        ...childElement.props,
+        onClick: combinedOnClick,
         ref
       })
     }


### PR DESCRIPTION
Fixes TypeScript error in `DialogTrigger` by ensuring `onClick` and `ref` type compatibility when cloning child elements.

---
<a href="https://cursor.com/background-agent?bcId=bc-1fd74349-d3fc-401c-805b-8dc6ab0d7b37">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-1fd74349-d3fc-401c-805b-8dc6ab0d7b37">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>