### PR TITLE
Fix social upload api filename type

### DIFF
--- a/pet-management-app/src/app/api/uploads/social/[...filename]/route.ts
+++ b/pet-management-app/src/app/api/uploads/social/[...filename]/route.ts
@@ -5,10 +5,11 @@ import { existsSync } from 'fs'
 
 export async function GET(
   request: NextRequest,
-  { params }: { params: { filename: string[] } }
+  { params }: { params: Promise<{ filename: string[] }> }
 ) {
   try {
-    const filename = params.filename.join('/')
+    const resolvedParams = await params
+    const filename = resolvedParams.filename.join('/')
     
     // Security: Prevent directory traversal
     if (filename.includes('..') || filename.includes('/')) {


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Update `GET` route handler `params` type to `Promise` to resolve TypeScript error in Next.js App Router.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
In Next.js 13+, the `params` object passed to route handlers is a Promise, requiring it to be awaited before accessing its properties. This PR updates the type definition and adds the necessary `await` to align with the current API and fix the type error.

---
<a href="https://cursor.com/background-agent?bcId=bc-d391cd4e-f85c-4975-b4d5-2516208b7f3c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d391cd4e-f85c-4975-b4d5-2516208b7f3c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>