### PR TITLE
Ollama manual start and status reporting

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "workspace",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}

--- a/pet-management-app/src/app/page.tsx
+++ b/pet-management-app/src/app/page.tsx
@@ -146,7 +146,7 @@ export default function DashboardPage() {
       // No session, stop loading
       setIsLoading(false)
     }
-  }, [session, sessionLoading, hasMounted, loadDashboardData])
+  }, [session, sessionLoading, hasMounted])
 
   const formatCurrency = (amount: number) => {
     return new Intl.NumberFormat('de-DE', {


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Remove `loadDashboardData` from `useEffect` dependencies to fix an infinite re-render loop.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The `loadDashboardData` function, wrapped in `useCallback` with an empty dependency array, was incorrectly included in the `useEffect`'s dependency array. This caused the `useEffect` to re-run on every render because `loadDashboardData` was perceived as a new function reference, leading to a "Maximum update depth exceeded" error.

---
<a href="https://cursor.com/background-agent?bcId=bc-a0868ab2-721f-471b-98fd-83ae01325dde">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a0868ab2-721f-471b-98fd-83ae01325dde">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>