### PR TITLE
Fix useEffect dependency warning

### DIFF
--- a/pet-management-app/src/app/page.tsx
+++ b/pet-management-app/src/app/page.tsx
@@ -146,7 +146,7 @@ export default function DashboardPage() {
       // No session, stop loading
       setIsLoading(false)
     }
-  }, [session, sessionLoading, hasMounted])
+  }, [session, sessionLoading, hasMounted, loadDashboardData])
 
   const formatCurrency = (amount: number) => {
     return new Intl.NumberFormat('de-DE', {


### PR DESCRIPTION
Add `loadDashboardData` to `useEffect` dependencies to resolve React Hook warning.

The `useEffect` hook was calling `loadDashboardData` but not including it in its dependency array, leading to a `react-hooks/exhaustive-deps` warning. Since `loadDashboardData` is memoized with `useCallback` and an empty dependency array, adding it to the `useEffect` dependencies is safe and resolves the warning without causing unnecessary re-renders.

---
<a href="https://cursor.com/background-agent?bcId=bc-f7b8df77-5914-4649-9f3d-f5dfa7948d7a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f7b8df77-5914-4649-9f3d-f5dfa7948d7a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>