### PR TITLE
Fix unused variable in PWAWrapper

### DIFF
--- a/pet-management-app/src/components/PWAWrapper.tsx
+++ b/pet-management-app/src/components/PWAWrapper.tsx
@@ -8,7 +8,6 @@ interface PWAWrapperProps {
 
 export function PWAWrapper({ children }: PWAWrapperProps) {
   const [isPWA, setIsPWA] = useState(false)
-  const [isStandalone, setIsStandalone] = useState(false)
 
   useEffect(() => {
     // Check if running as PWA
@@ -18,7 +17,6 @@ export function PWAWrapper({ children }: PWAWrapperProps) {
       const isPWA = isStandaloneMode || isInWebApp
       
       setIsPWA(isPWA)
-      setIsStandalone(isStandaloneMode)
       
       // Add PWA-specific classes to body
       if (isPWA) {


### PR DESCRIPTION
Remove unused `isStandalone` state variable to resolve ESLint error.

---
<a href="https://cursor.com/background-agent?bcId=bc-c7f58a25-fa9b-43a0-8126-d0fbe4169df4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c7f58a25-fa9b-43a0-8126-d0fbe4169df4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>