### PR TITLE
Fix navigator standalone type error

### DIFF
--- a/pet-management-app/src/components/PWAWrapper.tsx
+++ b/pet-management-app/src/components/PWAWrapper.tsx
@@ -13,7 +13,7 @@ export function PWAWrapper({ children }: PWAWrapperProps) {
     // Check if running as PWA
     const checkPWA = () => {
       const isStandaloneMode = window.matchMedia('(display-mode: standalone)').matches
-      const isInWebApp = window.navigator.standalone === true
+      const isInWebApp = (window.navigator as any).standalone === true
       const isPWA = isStandaloneMode || isInWebApp
       
       setIsPWA(isPWA)


### PR DESCRIPTION
Fixes TypeScript error by adding type assertion for `window.navigator.standalone`.

The `standalone` property is Safari-specific and not part of the standard `Navigator` interface, so a type assertion `(window.navigator as any)` is used to allow its access and resolve the compilation error.

---
<a href="https://cursor.com/background-agent?bcId=bc-9f027059-6c64-4627-83b4-9e0439fee083">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-9f027059-6c64-4627-83b4-9e0439fee083">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>