### PR TITLE
Fix typescript any type errors

### DIFF
--- a/pet-management-app/src/lib/session-types.ts
+++ b/pet-management-app/src/lib/session-types.ts
@@ -13,7 +13,7 @@ export interface AuthenticatedSession {
 }
 
 export async function getAuthenticatedSession(): Promise<AuthenticatedSession | null> {
-  const session = await getServerSession(authOptions as any) as { user?: { id?: string } } | null
+  const session = await getServerSession(authOptions) as { user?: { id?: string } } | null
   if (!session?.user?.id) {
     return null
   }

--- a/pet-management-app/src/pages/api/auth/[...nextauth].ts
+++ b/pet-management-app/src/pages/api/auth/[...nextauth].ts
@@ -1,4 +1,4 @@
 import NextAuth from "next-auth/next"
 import { authOptions } from "@/lib/auth"
 
-export default NextAuth(authOptions as any)
+export default NextAuth(authOptions)


### PR DESCRIPTION
Remove `as any` type assertions to resolve `@typescript-eslint/no-explicit-any` errors.

---
<a href="https://cursor.com/background-agent?bcId=bc-23d5bf4d-2b91-43fa-bddf-d1968c89ed0e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-23d5bf4d-2b91-43fa-bddf-d1968c89ed0e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>